### PR TITLE
change errorStrategy to retry in most cases

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -14,9 +14,9 @@ process {
 
   cpus = { check_max( 2, 'cpus' ) }
   memory = { check_max( 8.GB * task.attempt, 'memory' ) }
-  time = { check_max( 2.h * task.attempt, 'time' ) }
+  time = { check_max( 4.h * task.attempt, 'time' ) }
 
-  errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'terminate' }
+  errorStrategy = { task.exitStatus in [1,2,126,127,128,130] ? 'finish' : 'retry' }
   maxRetries = 1
   maxErrors = '-1'
 


### PR DESCRIPTION
A lot of processes had been terminated in the past by AWS Batch for various reasons. These processes have no exit codes so the pipeline was terminated. Changed the errorStrategy to "retry" on most occasions include those with no exit code, and to "finish" instead of "terminate" so that other submitted process are finished, not wasting already spent compute resources.