### PR TITLE
Fix cow genome file path typo

### DIFF
--- a/bin/check_design.py
+++ b/bin/check_design.py
@@ -10,7 +10,7 @@ def check_design(DesignFileIn, DesignFileOut, Comparison, IgnoreR1):
     legal_pattern = r"^[a-zA-Z][a-zA-Z0-9_]*$"
     illegal_patterns = ["_tophat", "ReadsPerGene", "_star_aligned", "_fastqc", "_counts", "Aligned", "_slamdunk", "_bismark", "_SummaryStatistics", \
                         "_duprate", "_vep", "ccs", "_NanoStats", "_R1", "_R2", "_trimmed", "_val", "_mqc", "short_summary_", "_summary", "_matrix", \
-                        r"_$", r"^R1", r"^R2", "_plot_ERCC", "_DESeq_results", "_gProfiler_results", "_trimmed_first"]
+                        r"^R1", r"^R2", "_plot_ERCC", "_DESeq_results", "_gProfiler_results", "_trimmed_first"]
     
     with open(DesignFileIn, "r") as fin:
         # Check the header first

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -47,9 +47,9 @@ params {
             rRNA_gtf = "${baseDir}/assets/rRNA_gtf/Rnor_6.0.gtf"
         }
         "Bos_taurus[ARS-UCD1.2]" {
-            bed12 = "s3://aladdin-genomes/Bos_Taurus/Ensembl/ARS-UCD1.2/Annotation/Genes/genes.bed"
-            gtf = "s3://aladdin-genomes/Bos_Taurus/Ensembl/ARS-UCD1.2/Annotation/Genes/genes.gtf"
-            star = "s3://aladdin-genomes/Bos_Taurus/Ensembl/ARS-UCD1.2/Sequence/STARIndex/"
+            bed12 = "s3://aladdin-genomes/Bos_taurus/Ensembl/ARS-UCD1.2/Annotation/Genes/genes.bed"
+            gtf = "s3://aladdin-genomes/Bos_taurus/Ensembl/ARS-UCD1.2/Annotation/Genes/genes.gtf"
+            star = "s3://aladdin-genomes/Bos_taurus/Ensembl/ARS-UCD1.2/Sequence/STARIndex/"
             gprofiler = "btaurus"
             ensembl_web = "www.ensembl.org"
             rRNA_gtf = "${baseDir}/assets/rRNA_gtf/ARS-UCD1.2.gtf"


### PR DESCRIPTION
Fixed a typo in Bos taurus genome file paths.
Removed a reserved string r"_$" in sample labels. Even though this will get chopped off by MultiQC, it doesn't significantly affect the looks of the report.