### PR TITLE
add compatible_clouds

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -3,6 +3,7 @@
     "$id": "https://raw.githubusercontent.com/Zymo-Research/aladdin-rnaseq/master/nextflow_schema.json",
     "title": "Zymo-Research/aladdin-rnaseq pipeline parameters",
     "description": "Nextflow RNA-Seq analysis pipeline, part of the Zymo Research bioinformatics pipeline catalog",
+    "compatible_clouds": ["awsbatch", "zymohpc"],
     "metadata_columns": {
         "type": "object",
         "properties": {

--- a/processes/bbduk.nf
+++ b/processes/bbduk.nf
@@ -34,6 +34,6 @@ process bbduk {
         $entropy \\
         threads=$task.cpus \\
         &> ${meta.name}.bbduk.log
-    bbduk.sh --version &> v_bbduk.txt
+    bbduk.sh -Xmx1g --version &> v_bbduk.txt
     """
 }


### PR DESCRIPTION
add compatible_clouds to schema;
fix a bug where bbduk may exceed container memory on HPC